### PR TITLE
Magnitudes

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
-Unitful 0.3.0
+Unitful 0.4.0
 UnitfulAngles

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -52,6 +52,40 @@ julia> uconvert(u"ly", 1 * u"pc")
 3.2615637771674337 ly
 ```
 
+## Magnitudes
+
+!!! warn
+    Support for magnitudes is experimental. Please use care and report any issues you experience on
+    the [UnitfulAstro.jl GitHub issue
+    tracker](https://github.com/JuliaAstro/UnitfulAstro.jl/issues).
+
+Currently only AB and bolometric magnitudes are supported.
+
+For example
+
+```jldoctest
+julia> using Unitful, UnitfulAstro
+       u = UnitfulAstro;
+
+julia> 5*u.mag_AB + 5*u.mag_AB
+4.247425010840047 magᴬᴮ
+
+julia> 5*u.mag_AB / 100
+10.0 magᴬᴮ
+
+julia> 5*u.mag_AB + 10*u.Jy # magnitudes can be mixed with ordinary linear units
+46.31 Jy
+
+julia> uconvert(u.mag_AB, 1*u.μJy) # converting one μJy to AB magnitudes
+23.90006562228223 magᴬᴮ
+
+julia> uconvert(u.mag_bol, 1*u.Ssun) # apparent bolometric magnitude of the Sun
+-26.83199694276591 magᵇᵒˡ
+
+julia> uconvert(u.Mag_bol, 1*u.Lsun) # absolute bolometric magnitude of the Sun
+4.7399959339194595 Magᵇᵒˡ
+```
+
 ## IAU Resolutions
 
 Copies of recent IAU resolutions which formalize the definitions of some units used in this package

--- a/src/UnitfulAstro.jl
+++ b/src/UnitfulAstro.jl
@@ -82,6 +82,10 @@ import UnitfulAngles: arcminute, arcsecond
 # Total electron content unit (used for ionospheric physics and low-frequency radio astronomy)
 @unit TECU       "TECU"     TotalElectronContentUnit  1e16*m^-2                 false
 
+# Experimental support for magnitudes
+Unitful.@logscale mag    "mag"      Magnitude    10    -2.5    false
+Unitful.@logunit  mag_AB "magᴬᴮ"    Magnitude    3631Jy
+
 const localunits = Unitful.basefactors
 function __init__()
     merge!(Unitful.basefactors, localunits)

--- a/src/UnitfulAstro.jl
+++ b/src/UnitfulAstro.jl
@@ -83,8 +83,17 @@ import UnitfulAngles: arcminute, arcsecond
 @unit TECU       "TECU"     TotalElectronContentUnit  1e16*m^-2                 false
 
 # Experimental support for magnitudes
-Unitful.@logscale mag    "mag"      Magnitude    10    -2.5    false
-Unitful.@logunit  mag_AB "magᴬᴮ"    Magnitude    3631Jy
+# ===================================
+# Note that we will use the convention that "mag" refers to an apparent magnitude and "Mag" refers
+# to an absolute magnitude.
+Unitful.@logscale mag     "mag"      Magnitude    10    -2.5    false
+
+# AB Magnitudes
+Unitful.@logunit  mag_AB  "magᴬᴮ"    Magnitude    3631Jy
+
+# Bolometric magnitudes (cf IAU 2015)
+Unitful.@logunit  Mag_bol "Magᵇᵒˡ"   Magnitude    3.0128e28*W
+Unitful.@logunit  mag_bol "magᵇᵒˡ"   Magnitude    2.518_021_002e-8*W*m^-2
 
 const localunits = Unitful.basefactors
 function __init__()
@@ -93,3 +102,4 @@ function __init__()
 end
 
 end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,5 +24,9 @@ const u = UnitfulAstro
         # Solar flux at Earth's surface
         @test isapprox(1*u.Lsun/(4π*u.AU^2), 1*u.Ssun, atol=0.001*u.Ssun)
     end
+
+    @testset "magnitudes" begin
+        @test 3631*u.Jy == 1*u.mag_AB
+    end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using UnitfulAstro
+using Unitful, UnitfulAstro
 using Base.Test
 
 const u = UnitfulAstro
@@ -26,7 +26,13 @@ const u = UnitfulAstro
     end
 
     @testset "magnitudes" begin
-        @test 3631*u.Jy == 1*u.mag_AB
+        @test 3631*u.Jy ≈ 0*u.mag_AB
+        @test 36.31*u.Jy ≈ 5*u.mag_AB
+        @test 363.1*u.mJy ≈ 10*u.mag_AB
+        @test 3.631*u.mJy ≈ 15*u.mag_AB
+        @test 5*u.mag_AB + 5*u.mag_AB ≈ 4.247425010840047*u.mag_AB
+        @test 5*u.mag_AB / 100 ≈ 10*u.mag_AB
+        @test 5*u.mag_AB + 10*u.Jy ≈ 46.31*u.Jy
     end
 end
 


### PR DESCRIPTION
We can't merge this yet because we need to wait on a new tag of Unitful.jl, however I thought I'd open this PR to gather some feedback.

Currently I've implemented AB magnitudes and (apparent/absolute) bolometric magnitudes. I'm a radio astronomer though (I only ever use Janskys), so I don't really know what else is important to include. Do we want Vega magnitudes for some common filters?

Surface brightness seems to work as well. Although I think the printing for arcseconds is somewhat unfortunate.
```julia
julia> using Unitful, UnitfulAstro
       u = UnitfulAstro

julia> S = (20*u.mag_AB/u.arcsecond^2)
[20.0 magᴬᴮ] ″^-2

julia> uconvert(u"Jy/arcsecond^2", S)
3.631e-5 ″^-2 Jy

julia> S*10u.arcsecond^2
17.5 magᴬᴮ
```