### PR TITLE
Project.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 *.jl.*.cov
 *.jl.mem
 *.swp
-
+Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
 julia:
   - 1.0
   - 1.1
+  - 1.2
   - nightly
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
 julia:
   - 0.7
   - 1.0
+  - 1.1
   - nightly
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
   - 1.0
   - 1.1
   - nightly

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,18 @@
+name = "UnitfulAstro"
+uuid = "f2a1aa4e-5634-4978-a6f6-8c9e368f14ef"
+license = "MIT"
+version = "0.3.0"
+
+[deps]
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+UnitfulAngles = "6fb2a4bd-7999-5318-a3b2-8ad61056cd98"
+
+[compat]
+Unitful = "≥ 0.7.1"
+julia = "≥ 0.7.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAngles = "6fb2a4bd-7999-5318-a3b2-8ad61056cd98"
 
 [compat]
-Unitful = "≥ 0.7.1"
+Unitful = "≥ 0.13.0"
 julia = "≥ 0.7.0"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ UnitfulAngles = "6fb2a4bd-7999-5318-a3b2-8ad61056cd98"
 
 [compat]
 Unitful = "≥ 0.13.0"
-julia = "≥ 0.7.0"
+julia = "≥ 1.0.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnitfulAstro"
 uuid = "f2a1aa4e-5634-4978-a6f6-8c9e368f14ef"
 license = "MIT"
-version = "0.3.0"
+version = "0.2.0"
 
 [deps]
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,0 @@
-julia 0.7
-Unitful 0.7.1
-UnitfulAngles

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ environment:
   matrix:
   - julia_version: 1
   - julia_version: 1.1
+  - julia_version: 1.2
   - julia_version: nightly
 
 platform:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - julia_version: 0.7
   - julia_version: 1
+  - julia_version: 1.1
   - julia_version: nightly
 
 platform:

--- a/src/UnitfulAstro.jl
+++ b/src/UnitfulAstro.jl
@@ -34,9 +34,9 @@ function should_we_use_SI_prefixes(arg::Expr)
 end
 should_we_use_SI_prefixes(arg::Symbol) = false, arg
 
-@import_from_unitful ~m ~s ~A ~K ~cd ~g ~mol
+@import_from_unitful ~m ~s ~A ~K ~cd
 @import_from_unitful ~L ~Hz ~N ~Pa ~J ~W ~C ~V ~Ω ~S ~F ~H ~T ~Wb ~lm ~lx ~Bq ~Gy ~Sv ~kat ~eV
-@import_from_unitful sr rad ° °C °Ra °F minute hr d wk ~bar atm Torr
+@import_from_unitful sr rad ° °C °F minute hr d wk ~bar atm Torr
 @import_from_unitful q c0 c μ0 µ0 ε0 ϵ0 Z0 G gn ge h ħ Φ0 me mn mp μB µB Na R k σ
 @import_from_unitful inch ft yd mi ac lb oz dr gr lbf
 

--- a/src/UnitfulAstro.jl
+++ b/src/UnitfulAstro.jl
@@ -36,7 +36,7 @@ should_we_use_SI_prefixes(arg::Symbol) = false, arg
 
 @import_from_unitful ~m ~s ~A ~K ~cd
 @import_from_unitful ~L ~Hz ~N ~Pa ~J ~W ~C ~V ~Ω ~S ~F ~H ~T ~Wb ~lm ~lx ~Bq ~Gy ~Sv ~kat ~eV
-@import_from_unitful sr rad ° °C °F minute hr d wk ~bar atm Torr
+@import_from_unitful sr rad ° °C °F Ra minute hr d wk ~bar atm Torr
 @import_from_unitful q c0 c μ0 µ0 ε0 ϵ0 Z0 G gn ge h ħ Φ0 me mn mp μB µB Na R k σ
 @import_from_unitful inch ft yd mi ac lb oz dr gr lbf
 


### PR DESCRIPTION
In this pull request I've changed 3(ish) things.

1. I've added a `Project.toml` to work with the new Julia standards. I've copied the requirements from `REQUIRE` and added an appropriate `[compat]` section. 
2. I've bumped the version to 0.3.0 in the `Project.toml`
3. I've switched `° Ra` to `Ra` in the *import_from_unitful* section since default Unitful has removed the degree symbol