### PR TITLE
CI using Github actions, set compat to manual mode

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on: [push, pull_request, workflow_dispatch]
+
+# 64-bit Julia only
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, 'CompatHelper')"
+    strategy:
+      matrix:
+        version:
+          - '1.6.0'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        arch:
+          - x64
+    steps:
+      - run: echo ACTIONS_RUNNER_DEBUG true
+      - uses: actions/checkout@v1.0.0
+      - name: "Set up Julia"
+        uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      #- uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+        #env: 
+        #  ACTIONS_RUNNER_DEBUG: true
+      - uses: julia-actions/julia-uploadcodecov@latest
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.6.0'
+          - '1.3.0'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
+    if: "contains(github.event.head_commit.message, '[compat]')"
     steps:
       - uses: julia-actions/setup-julia@latest
         with:


### PR DESCRIPTION
In `CI.yml`, auto-test coverage is uploaded to https://about.codecov.io/ (by adding a github secret following the instructions there). You can also add a coverage badge in README.