### PR TITLE
Import `yr` unit from `Unitful` using appropriate macro

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnitfulAstro"
 uuid = "6112ee07-acf9-5e0f-b108-d242c714bf9f"
 license = "MIT"
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"

--- a/src/UnitfulAstro.jl
+++ b/src/UnitfulAstro.jl
@@ -3,7 +3,7 @@ __precompile__()
 module UnitfulAstro
 
 import Unitful
-using Unitful: @unit, @logscale, @logunit, yr
+using Unitful: @unit, @logscale, @logunit
 
 macro import_from_unitful(args...)
     expr = Expr(:block)
@@ -34,7 +34,7 @@ function should_we_use_SI_prefixes(arg::Expr)
 end
 should_we_use_SI_prefixes(arg::Symbol) = false, arg
 
-@import_from_unitful ~m ~s ~A ~K ~cd
+@import_from_unitful ~m ~s ~A ~K ~cd ~yr
 @import_from_unitful ~L ~Hz ~N ~Pa ~J ~W ~C ~V ~Ω ~S ~F ~H ~T ~Wb ~lm ~lx ~Bq ~Gy ~Sv ~kat ~eV
 @import_from_unitful sr rad ° °C °F Ra minute hr d wk ~bar atm Torr
 @import_from_unitful q c0 c μ0 µ0 ε0 ϵ0 Z0 G gn ge h ħ Φ0 me mn mp μB µB Na R k σ

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,8 @@ const u = UnitfulAstro
         @test 1.0*Unitful.angstrom ≈ 1e-10*u.m
         @test 1*u.SFU ≈ 10000*u.Jy
         @test 1*u.TECU == 1e12*u.cm^-2
+        # Make sure we can access Gyr directly from UnitfulAstro
+        @test 1*u.Gyr ≈ 1e9*u.yr
     end
 
     @testset "simple calculations" begin


### PR DESCRIPTION
In #22 I overlooked the fact that there is a specific macro in this package to better import a unit from `Unitful`.  By importing only `yr` we basically introduced a breaking change, since we're now missing in this package all multiples and submultiples of `yr`, like `Gyr`, which is needed for example by `Cosmology.jl`.  Reported in https://github.com/JuliaAstro/Cosmology.jl/pull/40 and https://github.com/JuliaAstro/Cosmology.jl/issues/41.

I think I'll yank v1.1.0 of UnitfulAstro.jl, since that was accidentally breaking